### PR TITLE
Add logging for missing COGS rows

### DIFF
--- a/update_monthly_scenario_calc.py
+++ b/update_monthly_scenario_calc.py
@@ -151,6 +151,7 @@ def main():
         # 8. Основной расчет
         print('🔄 Начинаем обработку строк...')
         out = []
+        skipped = 0
         for rowIdx, ps in enumerate(sales_data):
             org = ps[pIdx['Организация']]
             art = ps[pIdx['Артикул_поставщика']]
@@ -162,6 +163,9 @@ def main():
             pr    = rev_data[rowIdx]
             cKey  = f"{org}|{art}"
             unitC = cogs.get(cKey, {'rub': 0, 'rubWo': 0})
+            if cKey not in cogs:
+                print(f'Skip {art} ({org}) – no COGS found')
+                skipped += 1
 
             for idx, mKey in enumerate(MONTHS):
                 qty = to_num(ps[pIdx.get(mKey, -1)]) if mKey in pIdx else 0
@@ -186,6 +190,8 @@ def main():
                 ])
 
         print(f'✅ Обработка завершена. Всего строк для вывода: {len(out)}')
+        if skipped:
+            print(f'Skipped items due to missing COGS: {skipped}')
 
         # 9. Корректное формирование и запись умной таблицы
         hdr = [


### PR DESCRIPTION
## Summary
- log when a COGS record is missing
- show how many items were skipped due to missing COGS

## Testing
- `python -m py_compile update_monthly_scenario_calc.py`

------
https://chatgpt.com/codex/tasks/task_e_68460f646f34832aa9f48ee7b3fbdae3