### PR TITLE
FM-205 table formatting helpers

### DIFF
--- a/scripts/aggregator.py
+++ b/scripts/aggregator.py
@@ -7,6 +7,8 @@ import logging
 from datetime import datetime
 import os
 
+from scripts.style_utils import format_table
+
 BASE_DIR   = os.path.dirname(os.path.abspath(__file__))
 EXCEL_PATH = os.path.join(BASE_DIR, 'excel', 'Finmodel.xlsm')
 SHEET_NAME = 'НачисленияУслугОзон'
@@ -30,16 +32,11 @@ def write_to_excel(df: pd.DataFrame):
         sht.range("A1").value = df.columns.tolist()
         sht.range("A2").value = df.values.tolist()
 
-        # --- Оформление как умная таблица зелёный стиль (Medium 7) ---
+        # --- Оформление таблицы и шапки ---
         last_row = df.shape[0] + 1  # +1 для шапки
         last_col = df.shape[1]
         table_range = sht.range((1, 1), (last_row, last_col))
-        for tbl in sht.tables:
-            if tbl.name == "ServiceChargesTable":
-                tbl.delete()
-        sht.tables.add(table_range, name="ServiceChargesTable", table_style_name="TableStyleMedium7", has_headers=True)
-        sht.range('A1').expand().columns.autofit()
-        sht.api.Rows(1).Font.Bold = True
+        format_table(sht, table_range, "ServiceChargesTable")
         sht.api.Application.ActiveWindow.SplitRow = 1
         sht.api.Application.ActiveWindow.FreezePanes = True
 

--- a/scripts/create_ozon_economics_table.py
+++ b/scripts/create_ozon_economics_table.py
@@ -3,6 +3,8 @@
 import os
 import xlwings as xw
 
+from scripts.style_utils import autofit_safe
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 EXCEL_PATH = os.path.join(BASE_DIR, 'excel', 'Finmodel.xlsm')
 
@@ -217,7 +219,7 @@ def main():
 
         sheet.api.Tab.Color = 5296274  # зелёный
         sheet.api.Move(Before=wb.sheets[10].api)  # сделать вторым листом
-        sheet.autofit()
+        autofit_safe(sheet)
         sheet.api.Rows.AutoFit()
 # --- Закрепить только первую строку (шапку)
         sheet.api.Activate()

--- a/scripts/style_utils.py
+++ b/scripts/style_utils.py
@@ -1,0 +1,38 @@
+import xlwings as xw
+
+TABLE_STYLE = 'TableStyleMedium7'
+
+
+def format_table(ws: xw.main.Sheet, table_range: xw.main.Range, table_name: str,
+                 table_style: str = TABLE_STYLE) -> None:
+    """Create or replace a table and apply common formatting."""
+    try:
+        for tbl in ws.tables:
+            if tbl.name == table_name:
+                tbl.delete()
+    except Exception:
+        pass
+    ws.tables.add(table_range, name=table_name, table_style_name=table_style,
+                  has_headers=True)
+    try:
+        ws.range('A1').expand().columns.autofit()
+    except Exception:
+        try:
+            ws.autofit()
+        except Exception:
+            pass
+    try:
+        ws.api.Rows(1).Font.Bold = True
+    except Exception:
+        pass
+
+
+def autofit_safe(ws: xw.main.Sheet) -> None:
+    """Safely autofit all columns of a sheet."""
+    try:
+        ws.autofit()
+    except Exception:
+        try:
+            ws.range('A1').expand().columns.autofit()
+        except Exception:
+            pass

--- a/scripts/update_revenue_plan.py
+++ b/scripts/update_revenue_plan.py
@@ -5,6 +5,8 @@ import xlwings as xw
 import pandas as pd
 import re
 
+from scripts.style_utils import format_table
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 EXCEL_PATH = os.path.join(BASE_DIR, 'excel', 'Finmodel.xlsm') 
 
@@ -121,14 +123,8 @@ def main():
             rev_ws.range((sum_row, c)).number_format = '0 ₽'
 
         # Оформляем как умную таблицу
-        for tbl in rev_ws.tables:
-            if tbl.name == TABLE_NAME:
-                tbl.delete()
         table_range = rev_ws.range((1,1), (sum_row, total_col))
-        rev_ws.tables.add(table_range, name=TABLE_NAME, table_style_name=TABLE_STYLE, has_headers=True)
-
-        rev_ws.range('A1').expand().columns.autofit()
-        rev_ws.api.Rows(1).Font.Bold = True
+        format_table(rev_ws, table_range, TABLE_NAME)
         rev_ws.api.Application.ActiveWindow.SplitRow = 1
         rev_ws.api.Application.ActiveWindow.FreezePanes = True
         print('→ Данные и форматирование записаны')


### PR DESCRIPTION
## Summary
- add reusable Excel styling helpers
- use `format_table` in aggregator and revenue plan scripts
- use `autofit_safe` in Ozon economics table script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688200ed8edc832a9fceba827c8efcb3