### PR TITLE
Add tax cost column to planned indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ scripts/import_ozon_price_info.py
 📈 Экономика – update_monthly_scenario_calc.py, economics_table.py
 
 📊 Плановые показатели – fill_planned_indicators.py
+В PlannedIndicatorsTbl выводятся обе себестоимости: управленческая и налоговая.
 
 🖱️ ЗапуститьВсеРасчёты – макро‑оркестратор, выполняет 4 шага подряд.
 


### PR DESCRIPTION
## Summary
- show management and tax COGS in PlannedIndicatorsTbl
- format new column and update totals formulas
- test that management COGS exceeds tax COGS
- document dual COGS columns

## Testing
- `ruff check scripts/fill_planned_indicators.py tests/test_cargo_flow.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68821e540e7c832a80f53d0ab341b575