### PR TITLE
feat: Ozon economics – taxable COGS column support

### DIFF
--- a/tests/test_ozon_economics.py
+++ b/tests/test_ozon_economics.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from economics_table import compute_ozon_economics_df
+
+def test_taxable_cogs_column():
+    plan_df = pd.DataFrame({
+        'Организация': ['Org'],
+        'Артикул_поставщика': ['A1'],
+        'SKU': ['S1'],
+        'Плановая цена': [500],
+        'Мес.01': [1],
+    })
+    cost_df = pd.DataFrame({
+        'Организация': ['Org'],
+        'Артикул_поставщика': ['A1'],
+        'Себестоимость_руб': [100],
+        'Себестоимость_без_НДС_руб': [80],
+        'СебестоимостьУпр': [100],
+        'Себестоимость_Налог, руб (новый)': [300],
+    })
+    df = compute_ozon_economics_df(plan_df, cost_df, {})
+    assert df.loc[0, 'СебестоимостьНалог_руб'] == 300


### PR DESCRIPTION
## Summary
- compute Ozon economics table via new helper
- add totals row formatting
- expose helper for testing
- test taxable COGS column

## Testing
- `ruff check scripts/economics_table.py tests/test_ozon_economics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68823c1a09e8832ab0e5503181c62f8f