### PR TITLE
Fix duplicate get_workbook

### DIFF
--- a/scripts/update_monthly_scenario_calc.py
+++ b/scripts/update_monthly_scenario_calc.py
@@ -30,16 +30,6 @@ def wb_code_key(val):
     except Exception:
         return str(val).strip()
 
-def get_workbook():
-    try:
-        wb = xw.Book.caller()
-        app = None
-        from_caller = True
-    except Exception:
-        app = xw.App(visible=False)
-        wb = app.books.open(EXCEL_PATH)
-        from_caller = False
-    return wb, app, from_caller
 
 def idx_from_header(header_row):
     """Строит словарь индексов колонок по заголовкам"""


### PR DESCRIPTION
## Summary
- remove the first `get_workbook` definition so only one remains

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688249e12f24832aaa18a9e2aaae05ad