### PR TITLE
Fix subtotal formulas for ruble columns

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -723,12 +723,12 @@ def fill_planned_indicators():
         total_row = last_row + 1                 # ← исправили
         sh.range(total_row, 1).value = 'Итого'
 
-        for idx, col in enumerate(headers, start=1):
-            if col in ruble_cols:
-                letter = col_name(idx)
-                sh.range(total_row, idx).formula = \
-                    f"=SUBTOTAL(109,{letter}$2:{letter}${last_row})"
-                sh.range(total_row, idx).number_format = fmt
+        for col in ruble_cols:
+            idx = headers.index(col) + 1
+            letter = col_name(idx)
+            sh.range(total_row, idx).formula = \
+                f"=SUBTOTAL(109,{letter}$2:{letter}${last_row})"
+            sh.range(total_row, idx).number_format = fmt
 
 
         # ------ ярлык и позиция листа ----------------------------------


### PR DESCRIPTION
## Summary
- ensure subtotal formulas are inserted for all currency columns in `fill_planned_indicators.py`

## Testing
- `pip install -r /tmp/req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688250997070832abb45226d5c79808d