### PR TITLE
Add taxable cogs without VAT

### DIFF
--- a/scripts/calculate_cogs_batched.py
+++ b/scripts/calculate_cogs_batched.py
@@ -217,7 +217,7 @@ def main():
             'Организация', 'Артикул_поставщика', 'Предмет', 'Наименование',
             'Закуп_Цена_руб', 'Логистика_руб', 'Пошлина_руб', 'НДС_руб',
             'Себестоимость_руб', 'Себестоимость_без_НДС_руб', 'Входящий_НДС_руб',
-            'СебестоимостьУпр', 'СебестоимостьНалог'
+            'СебестоимостьУпр', 'СебестоимостьНалог', 'СебестоимостьНалог_без_НДС'
         ]
         result_ws.clear();  result_ws.range(1,1).value = header
         first_free = 2
@@ -282,14 +282,15 @@ def main():
                 # --- себестоимость по управленческому и налоговому учёту ---
                 total_cogs_full = purchase_rub + logistics_rub + duty_rub + vat_rub
                 is_deductible = logistics_mode != 'Карго'
-                cogs_mgmt = purchase_rub
+                cogs_mgmt = total_cogs_full
                 cogs_tax = total_cogs_full if is_deductible else 0
+                cogs_tax_wo = (total_cogs_full - vat_rub) if is_deductible else 0
 
                 batch_out.append([
                     org, vendor_orig, subject, name,
                     round(purchase_rub), round(logistics_rub), round(duty_rub),
                     round(vat_rub),      round(total_cogs),    round(cogs_without_vat),
-                    round(vat_rub), round(cogs_mgmt), round(cogs_tax)
+                    round(vat_rub), round(cogs_mgmt), round(cogs_tax), round(cogs_tax_wo)
                 ])
 
             if batch_out:
@@ -315,7 +316,7 @@ def main():
             rub_cols = [
                 'Закуп_Цена_руб', 'Логистика_руб', 'Пошлина_руб', 'НДС_руб',
                 'Себестоимость_руб', 'Себестоимость_без_НДС_руб', 'Входящий_НДС_руб',
-                'СебестоимостьУпр', 'СебестоимостьНалог'
+                'СебестоимостьУпр', 'СебестоимостьНалог', 'СебестоимостьНалог_без_НДС'
             ]
             headers = [c.Name for c in tbl.ListColumns]
             for col_name in rub_cols:


### PR DESCRIPTION
## Summary
- update COGS batch calculation
- include taxable cost without VAT column in output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826c0a196c832a9d5a6bd7a9cadcdc