### PR TITLE
Improve tax column lookup in planner

### DIFF
--- a/tests/test_find_key.py
+++ b/tests/test_find_key.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'scripts'))
+from fill_planned_indicators import find_key
+
+def test_find_key_punctuation():
+    idx = {
+        'себестоимостьналог': 0,
+        'себестоимостьпродажналог, ₽': 1,
+    }
+    assert find_key(idx, 'СебестоимостьНалог') == 'себестоимостьналог'
+    assert find_key(idx, 'СебестоимостьПродажНалог') == 'себестоимостьпродажналог, ₽'
+


### PR DESCRIPTION
## Summary
- normalize keys in `find_key` using only alphanumerics
- detect taxable cost columns via `find_key` when importing WB/Ozon data
- add unit test for `find_key`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f0e83fe4832a8e8d2c442eea12f9