### PR TITLE
Implement consolidated EBITDA tax calculation

### DIFF
--- a/tests/test_usn_consolidation.py
+++ b/tests/test_usn_consolidation.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'scripts'))
+from fill_planned_indicators import _apply_consolidated_dr_tax
+
+
+def test_consolidated_usn_min_tax_distribution():
+    rows = [
+        {'m': 1, 'revN': 1000, 'ebit_tax': 100, 'usn': 6},
+        {'m': 1, 'revN': 2000, 'ebit_tax': -200, 'usn': 6},
+    ]
+    totals = _apply_consolidated_dr_tax(rows)
+    assert totals[1] == -100
+    assert rows[0]['tax'] == 10
+    assert rows[1]['tax'] == 20
+    assert rows[0]['usn_forced_min']
+    assert rows[1]['usn_forced_min']


### PR DESCRIPTION
## Summary
- add `_apply_consolidated_dr_tax` helper
- compute and output **EBITDA налог сводно, ₽**
- distribute USN tax for consolidated `Доходы-Расходы`
- fix `_calc_row` logic
- test consolidated USN tax distribution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883531d0f84832aab3a2dd2e0e9b39d