### PR TITLE
Fix pandas import duplication

### DIFF
--- a/scripts/calc_payroll_contributions.py
+++ b/scripts/calc_payroll_contributions.py
@@ -11,8 +11,10 @@
 # Работает и из Excel-макроса (RunPython) и из терминала.
 
 # ---------- Пути --------------------------------------------------
-import os, sys, logging, xlwings as xw, pandas as pd
-from datetime import datetime
+import os
+import sys
+import logging
+import xlwings as xw
 import pandas as pd
 import datetime as dt
 import argparse
@@ -38,7 +40,7 @@ LOG_DIR     = os.path.join(PROJECT_DIR, 'log')
 
 os.makedirs(LOG_DIR, exist_ok=True)
 LOG_FILE = os.path.join(
-    LOG_DIR, f'calc_payroll_{datetime.now():%Y%m%d_%H%M%S}.log'
+    LOG_DIR, f'calc_payroll_{dt.datetime.now():%Y%m%d_%H%M%S}.log'
 )
 
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- remove duplicate pandas import in `calc_payroll_contributions`
- standardize datetime usage with `import datetime as dt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6883ae5e6b34832aa4bc280ec9f8d412