### PR TITLE
Handle comma separator in parse_money

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -83,9 +83,10 @@ def open_wb():
 def parse_money(v):
     if v in (None, ''):
         return 0.0
+    s = str(v).replace(' ', '').replace('₽', '').replace(',', '.')
     s = ''.join(
         c
-        for c in str(v).replace(' ', '').replace('₽', '')
+        for c in s
         if c.isdigit() or c in '-.'
     )
     return float(s)

--- a/tests/test_parse_money.py
+++ b/tests/test_parse_money.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from fill_planned_indicators import parse_money
+
+
+def test_parse_money_comma():
+    assert parse_money("1,5") == 1.5


### PR DESCRIPTION
## Summary
- correctly convert comma decimal separator in `parse_money`
- test for parsing of values like `"1,5"`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883af44b4a0832a987c663c84ca827f