### PR TITLE
Include VAT into DR expenses

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -186,12 +186,11 @@ def full_cogs(cn, nds):
     return cn * (1 + nds / 100)
 
 
-def _calc_row(revN, mpNet, cost, fot, esn, oth, mode):
+def _calc_row(revN, mpNet, cost_sales, cost_tax, fot, esn, oth, mode):
     """Calculate management and tax EBITDA for given inputs."""
-    cost_sales = cost
     ebit_mgmt = revN - (cost_sales + mpNet + fot + esn + oth)
     if mode == 'Доходы-Расходы':
-        ebit_tax = revN - (cost_sales + fot + esn + oth)
+        ebit_tax = revN - (cost_tax + fot + esn + oth)
     else:
         ebit_tax = ebit_mgmt
     return {'EBITDA, ₽': ebit_mgmt, 'EBITDA нал., ₽': ebit_tax}
@@ -570,12 +569,12 @@ def fill_planned_indicators():
                 cost_base = g['cr']
 
             cost_sales = cost_base
-            cost_tax = g.get('ct', full_cogs(g['cn'], nds) if round(nds) in (5, 7) else g['cn'])
+            cost_tax = g.get('ct', full_cogs(g['cn'], nds))
             cost_tax_wo = g.get('ct_wo', g['cn'])
             ebit_mgmt = revN - (cost_sales + mpNet + fot + esn + oth_cost)
             if mode_eff == 'Доходы-Расходы':
-                
-                ebit_tax = revN - (cost_sales + mpNet + fot + esn + oth_cost)
+
+                ebit_tax = revN - (cost_tax + fot + esn + oth_cost)
 
             else:
                 ebit_tax = ebit_mgmt

--- a/tests/test_ebit_split.py
+++ b/tests/test_ebit_split.py
@@ -4,7 +4,16 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / 'scripts'))
 from fill_planned_indicators import _calc_row
 
 
-def test_mp_excluded_from_tax():
-    row = _calc_row(revN=1000, mpNet=200, cost=300, fot=0, esn=0, oth=0, mode='Доходы-Расходы')
+def test_mp_excluded_from_tax_and_cogs_with_vat():
+    row = _calc_row(
+        revN=1000,
+        mpNet=200,
+        cost_sales=300,
+        cost_tax=360,
+        fot=0,
+        esn=0,
+        oth=0,
+        mode='Доходы-Расходы'
+    )
     assert row['EBITDA, ₽'] == 500
-    assert row['EBITDA нал., ₽'] == 700
+    assert row['EBITDA нал., ₽'] == 640


### PR DESCRIPTION
## Summary
- deduct COGS with VAT for USN `Доходы-Расходы`
- adjust helper and test to reflect VAT-inclusive tax EBITDA

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b0cc8a74832a8e4fa27b352a583b