### PR TITLE
Implement minimal USN tax for consolidated groups

### DIFF
--- a/tests/test_usn_consolidation.py
+++ b/tests/test_usn_consolidation.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'scripts'))
-from fill_planned_indicators import _apply_consolidated_dr_tax
+from fill_planned_indicators import _apply_consolidated_dr_tax, calc_consolidated_min_tax
 
 
 def test_consolidated_usn_min_tax_distribution():
@@ -16,3 +16,10 @@ def test_consolidated_usn_min_tax_distribution():
     assert rows[1]['tax'] == 20
     assert rows[0]['usn_forced_min']
     assert rows[1]['usn_forced_min']
+
+
+def test_calc_consolidated_min_tax():
+    tax = calc_consolidated_min_tax(100, 5000, 0.15)
+    assert tax == 50
+    tax = calc_consolidated_min_tax(1000, 2000, 0.06)
+    assert tax == 60


### PR DESCRIPTION
## Summary
- add helper to compute USN tax with consolidated 1% minimum
- apply consolidated minimum rule in `fill_planned_indicators`
- test new helper

## Testing
- `ruff check scripts/fill_planned_indicators.py tests/test_usn_consolidation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f653825c832ab24e3e7dd486ad3e