### PR TITLE
Fix test for consolidate_osno_tax

### DIFF
--- a/tests/test_osno_consolidated_base.py
+++ b/tests/test_osno_consolidated_base.py
@@ -56,7 +56,10 @@ def test_tax_shown_only_once_in_consolidation():
         row = [0] * 30
         row[0] = org
         row[1] = 1
+        # 19 column is База налога: in tests treat it
+        # same as EBITDA for simplicity
         row[18] = ebit
+        row[19] = ebit
         row[26] = 'ОСНО'
         row[28] = tax
         row[29] = ebit - tax


### PR DESCRIPTION
## Summary
- update test_osno_consolidated_base to set EBITDA tax base column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688530e2c0a4832aa53c67916d4cbf64