### PR TITLE
Fix osno_cum init

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -757,7 +757,7 @@ def fill_planned_indicators():
         for r in out:
             tax = base = 0
             rate = '0%'
-            osno_cum = tax_base_cons_cum.get(r['m'], 0)
+            osno_cum = 0
             osno_cum_cons = ''
             if r['mode'] == 'Доходы':
                 base = max(r['revN'], 0)


### PR DESCRIPTION
## Summary
- fix OSNO cumulative calculations to assign values only inside the ОСНО branch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688536399058832a892b57f5bc407611