### PR TITLE
Fix OSNO tax reset after regime switch

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -820,9 +820,9 @@ def fill_planned_indicators():
                     group_key = ('consolidated'
                                  if org_cfg.get(r['org'], {}).get('consolidation', False)
                                  else r['org'])
-                    # Сбрасываем накопление только один раз при переходе группы
-                    if r['prevM'] != 'ОСНО' and group_key not in cum_osno:
-
+                    # Сбрасываем накопление при первом месяце после выхода
+                    # из режима ОСНО вне зависимости от наличия записи
+                    if r['prevM'] != 'ОСНО':
                         cum_osno[group_key] = 0
 
                     # --- ключ для накопления прибыли/убытка ---


### PR DESCRIPTION
## Summary
- reset cumulative OSNO base whenever previous month wasn't `ОСНО`
- update helper in tests to mimic reset logic
- add regression test for OSNO base reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b0b6b418832a8d18f51eac029b80