### PR TITLE
Fix workbook path resolution

### DIFF
--- a/scripts/import_ozon_price_info.py
+++ b/scripts/import_ozon_price_info.py
@@ -5,11 +5,11 @@ import requests
 import xlwings as xw
 import pandas as pd
 from time import sleep
+from pathlib import Path
 from scripts.sheet_utils import apply_sheet_settings
 
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-EXCEL_PATH = os.path.join(BASE_DIR, 'excel', 'Finmodel.xlsm')
+EXCEL_PATH = str(Path(__file__).resolve().parents[1] / 'Finmodel.xlsm')
 
 SHEET_SETTINGS = 'НастройкиОрганизаций'
 SHEET_PRICES   = 'ЦеныОзон'

--- a/scripts/update_plan_sales.py
+++ b/scripts/update_plan_sales.py
@@ -16,10 +16,7 @@ def parse_cli():
 
 CLI_XLSM = parse_cli()                # None, если параметр не передали
 
-BASE_DIR  = Path(__file__).resolve().parent
-DEFAULT_XLSM = BASE_DIR.parent / 'excel' / 'Finmodel.xlsm'   # …\Finmodel\excel\Finmodel.xlsm
-
-EXCEL_PATH = str(Path(CLI_XLSM) if CLI_XLSM else DEFAULT_XLSM)
+EXCEL_PATH = str(Path(CLI_XLSM)) if CLI_XLSM else str(Path(__file__).resolve().parents[1] / 'Finmodel.xlsm')
 
 SHEET_SETTINGS   = 'Настройки'
 SHEET_PRODUCTS   = 'Номенклатура_WB'

--- a/scripts/update_plan_sales_ozon.py
+++ b/scripts/update_plan_sales_ozon.py
@@ -6,8 +6,10 @@ import pandas as pd
 import re
 from datetime import datetime
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-EXCEL_PATH = os.path.join(BASE_DIR, 'excel', 'Finmodel.xlsm')
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+EXCEL_PATH = str(BASE_DIR.parent / 'Finmodel.xlsm')
 
 SHEET_SETTINGS = 'Настройки'
 SHEET_SEASON   = 'Сезонность'


### PR DESCRIPTION
## Summary
- standardize workbook path lookup
- use repo root workbook for OZON sales scripts and price importer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b11489e8832a801823423bbd71cf