### PR TITLE
Fix payroll contribution summary sheet variable

### DIFF
--- a/scripts/calc_payroll_contributions.py
+++ b/scripts/calc_payroll_contributions.py
@@ -533,7 +533,14 @@ def main():
 
 
         # ── 6. Запись сводных листов ───────────────────────────────────
- 
+
+        sheet_name_sum = 'Свод'
+        sht_sum = (
+            wb.sheets[sheet_name_sum]
+            if sheet_name_sum in [s.name for s in wb.sheets]
+            else wb.sheets.add(sheet_name_sum)
+        )
+        sht_sum.clear()
 
         # зелёный ярлык и позиция
         try:


### PR DESCRIPTION
## Summary
- define worksheet `sht_sum` in payroll contribution script
- trim stray prompt text and ensure newline at EOF

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for pywin32==310)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xlwings')*

------
https://chatgpt.com/codex/tasks/task_e_6889c8fe3da0832a9ae3e8b20dc0d366