### PR TITLE
Add main entry point for fill_planned_indicators

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -1214,6 +1214,11 @@ def fill_planned_indicators():
 
 # ---------- 5. Точка входа -----------------------------------------------
 
-if __name__ == '__main__':
+def main():
+    """Entry point for xlwings and console execution."""
     fill_planned_indicators()
+
+
+if __name__ == '__main__':
+    main()
 


### PR DESCRIPTION
## Summary
- add a `main()` wrapper function in `fill_planned_indicators.py`
- invoke `main()` when running the script directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6889a8020900832a8187f1fc58116364