### PR TITLE
Fix NumberFormat error in fill_planned_indicators

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -1193,9 +1193,15 @@ def fill_planned_indicators():
         for col in ruble_cols:
             idx = headers.index(col) + 1
             letter = col_name(idx)
-            sh.range(total_row, idx).formula = \
-                f"=SUBTOTAL(109,{letter}$2:{letter}${last_row})"
-            sh.range(total_row, idx).api.NumberFormat = fmt
+            cell = sh.range(total_row, idx)
+            cell.formula = f"=SUBTOTAL(109,{letter}$2:{letter}${last_row})"
+            if not IS_EXE:
+                try:
+                    cell.api.NumberFormat = fmt
+                except Exception as e:
+                    log_info(f"[FORMAT] Итоговая колонка {idx} — ошибка: {e}")
+            else:
+                log_info("[FORMAT] Пропущено формат NumberFormat для итогов — запуск в .exe режиме")
 
 
         # ------ ярлык и позиция листа ----------------------------------


### PR DESCRIPTION
## Summary
- catch Excel formatting errors when writing totals in `fill_planned_indicators`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xlwings')*

------
https://chatgpt.com/codex/tasks/task_e_688a45dda7ac832aa37682143f0e9f08