### PR TITLE
Improve logging when running as exe

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -95,6 +95,7 @@ def open_wb():
         log_info(f'→ Excel-режим: {wb.fullname}')
     except Exception:       # запуск из терминала
         if not EXCEL_PATH.exists():
+            log_info(f"❌ Workbook not found: {EXCEL_PATH}")
             raise FileNotFoundError(f"Workbook not found: {EXCEL_PATH}")
         app = xw.App(visible=False, add_book=False)
         wb  = app.books.open(EXCEL_PATH, read_only=False)
@@ -1222,7 +1223,12 @@ def fill_planned_indicators():
 
 def main():
     """Entry point for xlwings and console execution."""
-    fill_planned_indicators()
+    log_info('=== Запуск fill_planned_indicators ===')
+    try:
+        fill_planned_indicators()
+    except Exception as e:
+        logging.exception('Ошибка выполнения: %s', e)
+        raise
 
 
 if __name__ == '__main__':

--- a/tests/test_open_wb_error.py
+++ b/tests/test_open_wb_error.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+import importlib
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+import fill_planned_indicators
+
+
+def test_open_wb_missing(tmp_path, monkeypatch):
+    fake_path = tmp_path / "missing.xlsm"
+    monkeypatch.setattr(fill_planned_indicators, "EXCEL_PATH", fake_path)
+    with pytest.raises(FileNotFoundError):
+        fill_planned_indicators.open_wb()


### PR DESCRIPTION
## Summary
- log missing workbook in `fill_planned_indicators.open_wb`
- report any exception from `main()` via logging
- add test for missing workbook

## Testing
- `ruff check .` *(fails: E701, E722, F401, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a6abd99ec832a8f031d57a257ee91