### PR TITLE
Clean ruff warnings

### DIFF
--- a/scripts/calculate_avg_logistics.py
+++ b/scripts/calculate_avg_logistics.py
@@ -25,7 +25,8 @@ def get_workbook():
 
 def safe_float(val):
     try:
-        if pd.isna(val): return 0.0
+        if pd.isna(val):
+            return 0.0
         return float(str(val).replace(',', '.').replace('\xa0', '').replace(' ', ''))
     except Exception:
         return 0.0
@@ -40,7 +41,8 @@ def main():
         print(f'→ Прочитано строк из {SHEET_SOURCE}: {len(df)}')
     except Exception as e:
         print(f'❌ Нет листа {SHEET_SOURCE}: {e}')
-        if app: app.quit()
+        if app:
+            app.quit()
         return
 
     # Проверяем нужные колонки
@@ -52,7 +54,8 @@ def main():
     for c in required:
         if c not in df.columns:
             print(f'❌ Нет колонки {c} в {SHEET_SOURCE}')
-            if app: app.quit()
+            if app:
+                app.quit()
             return
 
     log_fields = [
@@ -74,7 +77,8 @@ def main():
     for _, row in df.iterrows():
         qty = safe_float(row["ПроданоШт"])
         full_log = safe_float(row["Логистика"])
-        if qty == 0: continue
+        if qty == 0:
+            continue
         total_qty += qty
         total_log += full_log
 
@@ -115,7 +119,7 @@ def main():
         out_ws = wb.sheets[SHEET_OUT]
         out_ws.clear()
         print(f'→ Лист {SHEET_OUT} очищен')
-    except:
+    except Exception:
         out_ws = wb.sheets.add(SHEET_OUT)
         print(f'→ Лист {SHEET_OUT} создан')
 
@@ -132,7 +136,9 @@ def main():
     out_ws.api.Rows(1).Font.Bold = True
 
     print('=== Скрипт успешно завершён ===')
-    if app: wb.save(); app.quit()
+    if app:
+        wb.save()
+        app.quit()
 
 if __name__ == '__main__':
     main()

--- a/scripts/calculate_cogs_batched.py
+++ b/scripts/calculate_cogs_batched.py
@@ -3,7 +3,6 @@
 import os
 import xlwings as xw
 import pandas as pd
-import math
 import logging
 import datetime
 import pathlib
@@ -75,7 +74,8 @@ def get_workbook():
 
 def safe_float(val):
     try:
-        if pd.isna(val): return 0.0
+        if pd.isna(val):
+            return 0.0
         return float(str(val).replace(',', '.').replace(' ', '').replace(' ', ''))
     except Exception:
         return 0.0
@@ -83,21 +83,22 @@ def safe_float(val):
 def read_settings(ws):
     df = ws.range(1, 1).expand().options(pd.DataFrame, header=1, index=False).value
     df = df.loc[:, ~df.columns.duplicated()]  # Убираем дубликаты
-    idx = {h: i for i, h in enumerate(df.columns)}
     vals = df.values.tolist()
     params = {}
     for row in vals:
         param = str(row[0])
         val = row[1] if len(row) > 1 else None
-        if not param: break
+        if not param:
+            break
         params[param] = val
 
     def get_num(name, default=0):
         v = params.get(name, default)
-        if v is None: return default
+        if v is None:
+            return default
         try:
             return float(str(v).replace(',', '.').replace('%','').replace(' ',''))
-        except:
+        except Exception:
             return default
 
     return {
@@ -121,7 +122,7 @@ def get_progress(ws):
     try:
         val = ws.range(PROGRESS_CELL).value
         return int(val) if val else 1
-    except:
+    except Exception:
         return 1
 
 def set_progress(ws, idx):
@@ -197,7 +198,8 @@ def main():
             'Себестоимость_руб', 'Себестоимость_без_НДС_руб', 'Входящий_НДС_руб',
             'СебестоимостьУпр', 'СебестоимостьНалог', 'СебестоимостьНалог_без_НДС'
         ]
-        result_ws.clear();  result_ws.range(1,1).value = header
+        result_ws.clear()
+        result_ws.range(1, 1).value = header
         first_free = 2
 
         # 6. Основной цикл по товарам чанками
@@ -304,12 +306,15 @@ def main():
         except Exception as e:
             log(f'Не удалось применить формат: {e}', 'warning')
         result_ws.autofit()
-        log("Готово, файл сохранён"); print("✓ Готово!")
+        log("Готово, файл сохранён")
+        print("✓ Готово!")
 
     finally:                           # ───── закрываем Excel, если нужен ─────
         if app is not None:
-            wb.save(); wb.close()
-            app.quit(); del app
+            wb.save()
+            wb.close()
+            app.quit()
+            del app
             log("Excel закрыт корректно")
 
 # ------------------------------------------

--- a/scripts/excel_writer.py
+++ b/scripts/excel_writer.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import xlwings as xw
 
 def write_to_excel(df, filename, sheet_name='Sheet1'):

--- a/scripts/import_ozon_price_info.py
+++ b/scripts/import_ozon_price_info.py
@@ -1,6 +1,5 @@
 # import_ozon_price_info.py
 
-import os
 import requests
 import xlwings as xw
 import pandas as pd

--- a/scripts/import_ozon_realization_grouped.py
+++ b/scripts/import_ozon_realization_grouped.py
@@ -2,15 +2,14 @@
 
 import warnings
 from collections import defaultdict
-
-warnings.filterwarnings("ignore", category=UserWarning)
 import requests
 import pandas as pd
-import glob
-import os            # ← импорт был здесь
+import os
 import re
 import xlwings as xw
 from datetime import datetime
+
+warnings.filterwarnings("ignore", category=UserWarning)
 
 def get_workbook():
     try:

--- a/scripts/import_wb_product_cards.py
+++ b/scripts/import_wb_product_cards.py
@@ -1,6 +1,8 @@
 import xlwings as xw
 import requests
-import sys, os
+import sys
+import os
+import time
 print("==== PYTHONPATH ====")
 print(sys.path)
 print("==== WORKDIR ====")
@@ -88,7 +90,7 @@ def main():
                 resp = requests.post(API_URL, json=payload, headers=headers, timeout=30)
             except Exception as e:
                 print(f'❌ Сетевая ошибка: {e}, попытка {page}')
-                import time; time.sleep(10)
+                time.sleep(10)
                 continue
 
             print(f'HTTP {resp.status_code}')

--- a/scripts/scenario_calculator.py
+++ b/scripts/scenario_calculator.py
@@ -1,15 +1,14 @@
 # scenario_calculator.py – «Что‑если»-модуль к fill_planned_indicators.py
 
 import argparse
-import os
-import xlwings as xw
+import sys
 from pathlib import Path
 from collections import defaultdict
 from fill_planned_indicators import (
     open_wb,             # открыть/подсоединиться к Excel-книге
     parse_money, parse_month,
-    nds_rate, ndfl_prog,
-    build_idx, read_rows
+    nds_rate,
+    read_rows
 )
 
 def normalize(s):
@@ -91,8 +90,10 @@ def group_records(raw):
         if key not in groups:
             groups[key] = dict(org=org, month=month, rev=0, mp=0, cr=0, cn=0)
         g = groups[key]
-        g['rev'] += rev; g['mp']  += mp
-        g['cr']  += cr;  g['cn'] += cn
+        g['rev'] += rev
+        g['mp'] += mp
+        g['cr'] += cr
+        g['cn'] += cn
     return list(groups.values())
 
 def make_cfg_dict(cfg_rows):
@@ -255,7 +256,8 @@ def main():
     finally:
         if wb:
             wb.save()
-            if app: app.quit()
+            if app:
+                app.quit()
 
 if __name__ == '__main__':
     main()

--- a/scripts/updateRevenuePlanOzon.py
+++ b/scripts/updateRevenuePlanOzon.py
@@ -33,7 +33,8 @@ def main():
         print(f"→ Прочитано строк из {SHEET_SALES}: {len(df)}")
     except Exception as e:
         print(f"❌ Нет листа {SHEET_SALES}: {e}")
-        if app: app.quit()
+        if app:
+            app.quit()
         return
 
     df = df[df['Организация'].str.lower() != 'итого']  # убираем строки "Итого", если есть
@@ -43,14 +44,16 @@ def main():
     print(f"→ Месячные столбцы: {month_cols}")
     if not month_cols:
         print("❌ Нет месячных колонок!")
-        if app: app.quit()
+        if app:
+            app.quit()
         return
 
     # Проверка нужных колонок
     for c in ['Организация', 'Артикул_поставщика', 'SKU', 'Плановая цена']:
         if c not in df.columns:
             print(f"❌ Нет колонки {c} в {SHEET_SALES}")
-            if app: app.quit()
+            if app:
+                app.quit()
             return
 
     # Вычислить выручку по месяцам и итог
@@ -72,7 +75,7 @@ def main():
         out_ws = wb.sheets[SHEET_OUT]
         out_ws.clear()
         print(f'→ Лист {SHEET_OUT} очищен')
-    except:
+    except Exception:
         out_ws = wb.sheets.add(SHEET_OUT)
         print(f'→ Лист {SHEET_OUT} создан')
 
@@ -121,7 +124,9 @@ def main():
     out_ws.api.Application.ActiveWindow.FreezePanes = True
 
     print("=== Скрипт успешно завершён ===")
-    if app: wb.save(); app.quit()
+    if app:
+        wb.save()
+        app.quit()
 
 if __name__ == '__main__':
     main()

--- a/scripts/update_plan_sales.py
+++ b/scripts/update_plan_sales.py
@@ -1,6 +1,5 @@
 # update_plan_sales.py
 
-import os
 import xlwings as xw
 import pandas as pd
 from datetime import datetime
@@ -32,7 +31,7 @@ def get_workbook():
     try:
         wb = xw.Book.caller()
         app = None
-        print(f'→ Запуск из Excel-макроса')
+        print('→ Запуск из Excel-макроса')
     except Exception:
         app = xw.App(visible=False)
         wb = app.books.open(EXCEL_PATH)
@@ -95,18 +94,22 @@ def main():
         print('→ Листы найдены')
     except Exception as e:
         print('❌ Ошибка загрузки листов:', e)
-        if app: app.quit()
+        if app:
+            app.quit()
         return
 
     # 1. Период усреднения
     settings = settings_ws.range(1,1).expand().options(pd.DataFrame, header=1, index=False).value
     dt_from = dt_to = None
     for _, row in settings.iterrows():
-        if str(row.iloc[0]).strip() == 'Период с': dt_from = parse_date(row.iloc[1])
-        if str(row.iloc[0]).strip() == 'Период по': dt_to   = parse_date(row.iloc[1])
+        if str(row.iloc[0]).strip() == 'Период с':
+            dt_from = parse_date(row.iloc[1])
+        if str(row.iloc[0]).strip() == 'Период по':
+            dt_to = parse_date(row.iloc[1])
     if not dt_from or not dt_to:
         print('❌ Не заданы "Период с/по" в Настройках')
-        if app: app.quit()
+        if app:
+            app.quit()
         return
     months_cnt = (dt_to.year-dt_from.year)*12 + (dt_to.month-dt_from.month) + 1
     print(f'→ Период: {dt_from.strftime("%d.%m.%Y")} - {dt_to.strftime("%d.%m.%Y")} ({months_cnt} мес.)')
@@ -187,8 +190,6 @@ def main():
 
     # Индексы
     idx_prod = {h: i for i, h in enumerate(products.columns)}
-    idx_facts = {h: i for i, h in enumerate(facts.columns)}
-    idx_price = {h: i for i, h in enumerate(prices.columns)}
 
     # 4. Подготовка списка товаров (ключ: Артикул_WB)
     prod_list = []
@@ -239,7 +240,6 @@ def main():
 
     # 7. Сбор продаж по месяцам (факты только текущий год)
     col_artwb  = 'Артикул_WB'
-    col_org    = 'Организация'
     col_date   = 'Дата'
     col_sold   = 'Итого_продано'
     qty_map = {norm_key(p['artwb']): [0]*12 for p in prod_list}
@@ -260,7 +260,8 @@ def main():
         key = norm_key(row[col_artwb])
         if pd.isna(d) or d.year != year_plan:
             continue
-        if key not in qty_map: continue
+        if key not in qty_map:
+            continue
 
         sold_raw = row[col_sold]
         sold = safe_num(sold_raw)
@@ -392,7 +393,9 @@ def main():
     else:
         print('Нет строк для вывода — таблица не создаётся')
 
-    if app: wb.save(); app.quit()
+    if app:
+        wb.save()
+        app.quit()
     print('=== Скрипт успешно завершён ===')
 
 if __name__ == '__main__':

--- a/scripts/update_plan_sales_ozon.py
+++ b/scripts/update_plan_sales_ozon.py
@@ -5,8 +5,8 @@ import xlwings as xw
 import pandas as pd
 import re
 from datetime import datetime
-
 from pathlib import Path
+import logging
 
 BASE_DIR = Path(__file__).resolve().parent
 EXCEL_PATH = str(BASE_DIR.parent / 'Finmodel.xlsm')
@@ -22,9 +22,7 @@ TABLE_STYLE    = 'TableStyleMedium7'
 MONTHS_CNT = 12
 MONTH_NAMES = [f'Мес.{str(i+1).zfill(2)}' for i in range(MONTHS_CNT)]
 CURRENT_MONTH = datetime.now().month
-CURRENT_YEAR = datetime.now().year 
-
-import logging
+CURRENT_YEAR = datetime.now().year
 
 # Настройка логирования
 LOG_PATH = os.path.join(BASE_DIR, 'plan_sales_ozon.log')
@@ -116,7 +114,8 @@ def main():
 
     if not period_from or not period_to:
         print('❌ Не найден период в настройках!')
-        if app: app.quit()
+        if app:
+            app.quit()
         return
 
     period_from = pd.to_datetime(period_from, dayfirst=True, errors='coerce')
@@ -142,7 +141,8 @@ def main():
         print(f'→ Лист {SHEET_SALES}: {len(sales_df)} строк')
     except Exception:
         print(f'❌ Нет листа {SHEET_SALES}')
-        if app: app.quit()
+        if app:
+            app.quit()
         return
 
     need_cols = {'Организация', 'Артикул_поставщика', 'SKU',
@@ -150,7 +150,8 @@ def main():
     missing = need_cols - set(sales_df.columns)
     if missing:
         print(f'❌ В {SHEET_SALES} нет колонок: {", ".join(missing)}')
-        if app: app.quit()
+        if app:
+            app.quit()
         return
 
     # normalize articles to match cost sheet
@@ -261,7 +262,7 @@ def main():
         plan_ws = wb.sheets[SHEET_PLAN]
         plan_ws.clear()
         print(f'→ Лист {SHEET_PLAN} очищен')
-    except:
+    except Exception:
         plan_ws = wb.sheets.add(SHEET_PLAN)
         print(f'→ Лист {SHEET_PLAN} создан')
 
@@ -313,7 +314,9 @@ def main():
     plan_ws.api.Application.ActiveWindow.FreezePanes = True
 
     print('=== Скрипт успешно завершён ===')
-    if app: wb.save(); app.quit()
+    if app:
+        wb.save()
+        app.quit()
 
 
 def get_workbook():

--- a/scripts/update_revenue_plan.py
+++ b/scripts/update_revenue_plan.py
@@ -48,7 +48,8 @@ def main():
         print(f'→ Лист {SHEET_SALES} считан, строк: {len(df)}')
     except Exception as e:
         print(f'❌ Ошибка: не найден лист {SHEET_SALES} или не удалось считать данные\n{e}')
-        if app: app.quit()
+        if app:
+            app.quit()
         return
 
     # 2. Убираем строки "Итого"
@@ -89,7 +90,7 @@ def main():
         rev_ws = wb.sheets[SHEET_REVENUE]
         rev_ws.clear()
         print(f'→ Лист {SHEET_REVENUE} очищен')
-    except:
+    except Exception:
         rev_ws = wb.sheets.add(SHEET_REVENUE)
         print(f'→ Лист {SHEET_REVENUE} создан')
     # --- Цвет ярлыка и позиция листа ---
@@ -131,7 +132,9 @@ def main():
     else:
         print('Нет данных для вывода — таблица не создаётся')
 
-    if app: wb.save(); app.quit()
+    if app:
+        wb.save()
+        app.quit()
     print('=== Скрипт успешно завершён ===')
 
 if __name__ == '__main__':

--- a/scripts/wb_report.py
+++ b/scripts/wb_report.py
@@ -3,6 +3,7 @@ import requests
 import datetime
 import time
 from collections import Counter
+import pandas as pd
 
 SHEET_SETTINGS  = "Настройки"
 SHEET_ORGS      = "НастройкиОрганизаций"
@@ -146,7 +147,6 @@ def drop_existing_table(ws, table_name="WbFactsTable"):
             tbl.api.Delete()
             return
 
-import pandas as pd
 def _norm(val: str) -> str:
     """
     Нормализует числовые/строковые коды:
@@ -217,7 +217,7 @@ def import_wb_detailed_reports(wb=None):
             
     log_step(ws_log, f"Найдены ранее загруженные строки: {len(existing_keys)}")
 
-    results, unique_reports = [], set()
+    results = []
     doc_types_counter = Counter()
 
     for row_idx, row in enumerate(org_data[1:], start=2):

--- a/tests/test_cogs_taxable.py
+++ b/tests/test_cogs_taxable.py
@@ -1,4 +1,3 @@
-import pandas as pd
 
 TAX_DEDUCTIBLE_BY_LOGISTIC = {'Карго': False, 'Белая': True}
 

--- a/tests/test_fill_planned_headers.py
+++ b/tests/test_fill_planned_headers.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import sys
-import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
 from fill_planned_indicators import build_idx, find_key, parse_money

--- a/tests/test_open_wb_error.py
+++ b/tests/test_open_wb_error.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-import importlib
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))

--- a/tests/test_redemption_rate.py
+++ b/tests/test_redemption_rate.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'scripts'))
-from update_monthly_scenario_calc import build_redemption_rate, wb_code_key
+from update_monthly_scenario_calc import build_redemption_rate
 
 
 def test_nmId_mapping_logistics():

--- a/tests/test_sheet_utils.py
+++ b/tests/test_sheet_utils.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import sys
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'scripts'))
-import types
 from sheet_utils import apply_sheet_settings, hex_to_excel_tab_color
 
 class FakeTab:


### PR DESCRIPTION
## Summary
- fix unused imports and style warnings reported by ruff
- split multi-statement lines and replace bare `except`
- keep imports tidy in tests and scripts

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688a772acb50832aa1620db5867e0585