### PR TITLE
Add parse_month unit tests

### DIFF
--- a/tests/test_parse_month.py
+++ b/tests/test_parse_month.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from fill_planned_indicators import parse_month
+
+
+def test_parse_month_various_formats():
+    assert parse_month("01.2024") == 1
+    assert parse_month("2024-03") == 3
+    assert parse_month(1.0) == 1
+    assert parse_month("abc") == 0
+


### PR DESCRIPTION
## Summary
- add new parse_month tests for varied formats

## Testing
- `pytest tests/test_parse_month.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae846308c832a94783672897f203b