### PR TITLE
Add configurable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ cd Finmodel
 venv\Scripts\activate
 python scripts/calculate_cogs_batched.py --help
 
+# пример запуска main.py с указанием путей
+python scripts/main.py --org_folder data/ozon --output_path excel/Finmodel.xlsm
+# значения по умолчанию можно задать в `config.ini`
+
 Линтинг – ruff check .
 
 Тесты – pytest -q (используется pytest-xlwings для интеграций с Excel)

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,3 @@
+[paths]
+org_folder = НачисленияУслугОзон/ИП Закирова Р.Х
+output_path = excel/Finmodel.xlsm

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,20 +1,67 @@
 # main.py
 
+from __future__ import annotations
+
+import argparse
+import configparser
+from pathlib import Path
+
 from file_loader import load_files
 from aggregator import aggregate_data
 from excel_writer import write_to_excel, write_df_to_excel_table
 
-def main():
-    org_folder = r"C:\Users\Public\Finmodel\НачисленияУслугОзон\ИП Закирова Р.Х"
-    files_df = load_files(org_folder)
+BASE_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = BASE_DIR / "config.ini"
+
+
+def read_config() -> tuple[str | None, str | None]:
+    """Read default paths from ``config.ini`` if present."""
+    if not CONFIG_PATH.exists():
+        return None, None
+
+    parser = configparser.ConfigParser()
+    parser.read(CONFIG_PATH)
+    org_folder = parser.get("paths", "org_folder", fallback=None)
+    output_path = parser.get("paths", "output_path", fallback=None)
+    return org_folder, output_path
+
+def main(args: list[str] | None = None) -> None:
+    """Aggregate files from ``org_folder`` and write into ``output_path``."""
+
+    cfg_org, cfg_out = read_config()
+
+    parser = argparse.ArgumentParser(description="Aggregate Ozon service charges")
+    parser.add_argument(
+        "--org_folder",
+        type=str,
+        default=cfg_org,
+        help="Folder with source organization files",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default=cfg_out,
+        help="Path to output Finmodel workbook",
+    )
+
+    parsed = parser.parse_args(args)
+
+    if parsed.org_folder is None or parsed.output_path is None:
+        parser.error("Both org_folder and output_path must be provided")
+
+    org_folder = (BASE_DIR / Path(parsed.org_folder)).expanduser()
+    output_path = (BASE_DIR / Path(parsed.output_path)).expanduser()
+
+    files_df = load_files(str(org_folder))
     result_df = aggregate_data(files_df)
-    output_path = r"C:\Users\Public\Finmodel\excel\Finmodel.xlsm"
-    sheet = 'НачисленияУслугОзон'
-    table = 'НачисленияУслугОзонTable'
+
+    sheet = "НачисленияУслугОзон"
+    table = "НачисленияУслугОзонTable"
+
     # 1. Сохраняем просто DataFrame на лист
-    write_to_excel(result_df, output_path, sheet_name=sheet)
+    write_to_excel(result_df, str(output_path), sheet_name=sheet)
     # 2. Преобразуем лист в умную таблицу (Excel Table)
-    write_df_to_excel_table(result_df, output_path, sheet, table)
+    write_df_to_excel_table(result_df, str(output_path), sheet, table)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- add `config.ini` with default directories
- read optional paths from config and CLI
- allow custom `org_folder` and `output_path` using `pathlib.Path`
- update README developer docs with example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688afda9faf8832aa5ee862bff79c886