### PR TITLE
[Finmodel] clarify workbook location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 - Python automation scripts live in `scripts/`.
-- Excel workbook `Finmodel.xlsm` is stored in `excel/`.
+- Excel workbook `Finmodel.xlsm` sits in the project root.
 - Unit tests live in `tests/`.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ venv\Scripts\activate
 python scripts/calculate_cogs_batched.py --help
 
 # пример запуска main.py с указанием путей
-python scripts/main.py --org_folder data/ozon --output_path excel/Finmodel.xlsm
+python scripts/main.py --org_folder data/ozon --output_path Finmodel.xlsm
 # значения по умолчанию можно задать в `config.ini`
 
 Линтинг – ruff check .

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,3 @@
 [paths]
 org_folder = НачисленияУслугОзон/ИП Закирова Р.Х
-output_path = excel/Finmodel.xlsm
+output_path = Finmodel.xlsm


### PR DESCRIPTION
## Summary
- fix workbook path in contributor docs
- adjust config.ini and README examples to use root workbook

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8ca1dd04832ab68c12251f693891