### PR TITLE
[Finmodel] add interpreter path checks

### DIFF
--- a/excel/mdlLauncher.bas
+++ b/excel/mdlLauncher.bas
@@ -1,0 +1,43 @@
+Attribute VB_Name = "mdlLauncher"
+Option Explicit
+
+Private Function ReadInterpreter(confPath As String) As String
+    Dim fso As Object, ts As Object, line As String
+    Dim projectPath As String, value As String
+
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    If Not fso.FileExists(confPath) Then Exit Function
+    Set ts = fso.OpenTextFile(confPath, 1)
+    Do Until ts.AtEndOfStream
+        line = Trim(ts.ReadLine)
+        If UCase$(Left$(line, 12)) = "PROJECT_PATH" Then
+            value = Split(line, "=")(1)
+            projectPath = Trim(value)
+        ElseIf UCase$(Left$(line, 11)) = "INTERPRETER" Then
+            value = Split(line, "=")(1)
+            value = Trim(value)
+            If projectPath <> "" Then
+                value = Replace(value, "%(PROJECT_PATH)s", projectPath)
+            End If
+            ReadInterpreter = value
+            Exit Do
+        End If
+    Loop
+    ts.Close
+End Function
+
+Public Sub RunTask()
+    Dim confPath As String
+    confPath = ThisWorkbook.Path & "\.xlwings.conf"
+    Dim interp As String
+    interp = ReadInterpreter(confPath)
+    If interp <> "" Then
+        If Dir(interp) = "" Then
+            MsgBox "Python interpreter not found. Run setup again or update .xlwings.conf.", vbExclamation
+            Exit Sub
+        End If
+    End If
+
+    ' Call Python task
+    RunPython "import xlwings_macro; xlwings_macro.run_aggregation()"
+End Sub

--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -21,6 +21,8 @@ import xlwings as xw
 import logging
 from pathlib import Path
 
+from scripts.utils import ensure_interpreter_path
+
 # Флаг отладки по месяцам. Значение может быть переопределено
 # через аргументы командной строки в ``parse_args``.
 DEBUG_MONTH = False
@@ -94,6 +96,7 @@ LIMIT_GROSS_USN = 450_000_000              # ₽
 # ---------- 3. Вспомогательные функции ------------------------------------
 def get_workbook():
     """Return ``(wb, app)``. ``app`` is ``None`` when called from Excel."""
+    ensure_interpreter_path()
     try:
         wb = xw.Book.caller()
         app = None

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _parse_xlwings_conf(path: Path) -> str | None:
+    """Return interpreter path from ``.xlwings.conf`` if present."""
+    conf: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        if "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        conf[key.strip()] = val.split(";", 1)[0].strip()
+    interp = conf.get("INTERPRETER")
+    if interp and "%(PROJECT_PATH)s" in interp:
+        interp = interp.replace("%(PROJECT_PATH)s", conf.get("PROJECT_PATH", ""))
+    return interp
+
+
+def ensure_interpreter_path() -> None:
+    """Raise ``FileNotFoundError`` if ``INTERPRETER`` path is invalid on Windows."""
+    if os.name != "nt":
+        return
+
+    conf_path = Path(__file__).resolve().parents[1] / ".xlwings.conf"
+    if not conf_path.exists():
+        return
+
+    interpreter = _parse_xlwings_conf(conf_path)
+    if interpreter and not Path(interpreter).exists():
+        raise FileNotFoundError(
+            f"Interpreter not found: {interpreter}. "
+            "Run setup again or update .xlwings.conf."
+        )


### PR DESCRIPTION
## Summary
- add a `utils` helper to validate the interpreter path from `.xlwings.conf`
- ensure the path exists in `fill_planned_indicators.get_workbook`
- provide updated `mdlLauncher` VBA module with the same check

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688ba9390364832a9799276c32c3fbd8