### PR TITLE
[Finmodel] handle non-deductible VAT in COGS

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -20,10 +20,10 @@ import argparse
 import xlwings as xw
 import logging
 from pathlib import Path
-import ctypes      # <-- ДОБАВЬТЕ наверху рядом с os, sys …
-from ctypes import wintypes
+import ctypes  # noqa: F401  # <-- ДОБАВЬТЕ наверху рядом с os, sys …
+from ctypes import wintypes  # noqa: F401
 
-from scripts.utils import ensure_interpreter_path
+from scripts.utils import ensure_interpreter_path  # noqa: F401
 
 # Флаг отладки по месяцам. Значение может быть переопределено
 # через аргументы командной строки в ``parse_args``.
@@ -244,8 +244,18 @@ def log_nds(month, org, prev, curr, mode, rate, lvl):
 
 
 def full_cogs(cn, nds):
-    """Return cost including non-refundable VAT for reduced rates."""
-    return cn * (1 + nds / 100)
+    """Return cost including non-deductible VAT difference.
+
+    Calculates cost of goods sold (Cn) including only the portion of VAT
+    that cannot be reclaimed. The model assumes input VAT of 20%. For sales
+    with a reduced VAT rate, only the difference between 20% and the applied
+    rate is added to cost. When the VAT rate is 20% or higher the cost is
+    returned unchanged.
+    """
+
+    if nds >= 20:
+        return cn
+    return cn * (1 + (20 - nds) / 100)
 
 
 def _calc_row(

--- a/tests/test_full_cogs.py
+++ b/tests/test_full_cogs.py
@@ -1,5 +1,9 @@
+import pytest
 from scripts.fill_planned_indicators import full_cogs
 
-def test_full_cogs_reduced_rates():
-    assert full_cogs(100, 5) == 105
-    assert full_cogs(200, 7) == 214
+
+def test_full_cogs_vat_rates():
+    assert full_cogs(100, 0) == pytest.approx(120)
+    assert full_cogs(100, 5) == pytest.approx(115)
+    assert full_cogs(200, 7) == pytest.approx(226)
+    assert full_cogs(300, 20) == 300


### PR DESCRIPTION
## Summary
- adjust `full_cogs` to add only non-deductible VAT difference and update docstring
- cover 0%, 5%, 7% and 20% VAT rates in `test_full_cogs_vat_rates`

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q` *(fails: xlwings.XlwingsError: The interactive mode of xlwings is only supported on Windows and macOS)*

------
https://chatgpt.com/codex/tasks/task_e_68a7187b992c832aa926355c5f0c2849