### PR TITLE
[Finmodel] simplify cost base and add VAT tests

### DIFF
--- a/tests/test_cost_base.py
+++ b/tests/test_cost_base.py
@@ -1,0 +1,15 @@
+import pytest
+from scripts.fill_planned_indicators import _calc_cost_base
+
+
+def test_cost_base_uses_cn_when_available():
+    assert _calc_cost_base(120, 150, 20) == 120
+
+
+@pytest.mark.parametrize("cr, nds, expected", [
+    (120, 20, 100),
+    (105, 5, 100),
+    (107, 7, 100),
+])
+def test_cost_base_fallback(cr, nds, expected):
+    assert _calc_cost_base(None, cr, nds) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- derive cost base from net or gross value without VAT-rate branching
- expose cost base for "Себестоимость без НДС" column
- cover cost base fallback for multiple VAT rates

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q` *(fails: xlwings interactive mode unsupported on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68a71a12bb68832ab889e0918ed67f86