### PR TITLE
[Finmodel] Validate net cost using gross cost tolerance

### DIFF
--- a/scripts/fill_planned_indicators.py
+++ b/scripts/fill_planned_indicators.py
@@ -262,15 +262,22 @@ def full_cogs(cn, nds):
         return cn
     return cn * (1 + (20 - nds) / 100)
 
+COST_BASE_TOLERANCE = 0.01  # 1% tolerance for rounding errors
 
 def _calc_cost_base(cn, cr, nds):
     """Return base cost excluding VAT.
 
     Uses provided net cost ``cn`` when available. Otherwise the base cost is
     derived from gross cost ``cr`` by removing VAT according to ``nds`` rate.
+    If ``cn`` is provided but deviates from ``cr`` by more than
+    ``COST_BASE_TOLERANCE`` percent, the net cost is recalculated from ``cr``.
     """
 
-    return cn if cn is not None else cr / (1 + nds / 100)
+    if cn is not None:
+        expected_cr = cn * (1 + nds / 100)
+        if abs(cr - expected_cr) <= expected_cr * COST_BASE_TOLERANCE:
+            return cn
+    return cr / (1 + nds / 100)
 
 
 def _calc_row(

--- a/tests/test_cost_base.py
+++ b/tests/test_cost_base.py
@@ -3,7 +3,15 @@ from scripts.fill_planned_indicators import _calc_cost_base
 
 
 def test_cost_base_uses_cn_when_available():
-    assert _calc_cost_base(120, 150, 20) == 120
+    assert _calc_cost_base(120, 144, 20) == 120
+
+
+def test_cost_base_recalculates_when_cn_incorrect():
+    cn = 120
+    cr = 160
+    nds = 20
+    expected = cr / (1 + nds / 100)
+    assert _calc_cost_base(cn, cr, nds) == pytest.approx(expected)
 
 
 @pytest.mark.parametrize("cr, nds, expected", [


### PR DESCRIPTION
## Summary
- add 1% tolerance constant and validate gross vs net cost in `_calc_cost_base`
- recalc cost base from gross when provided net cost deviates beyond tolerance
- cover miscalculated net cost with unit test

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7269ee314832abff596f3d25705fc