### PR TITLE
[Finmodel] Improve WB token validation and header checks

### DIFF
--- a/scripts/import_wb_product_cards.py
+++ b/scripts/import_wb_product_cards.py
@@ -3,6 +3,8 @@ import requests
 import sys
 import os
 import time
+from dataclasses import dataclass, field
+from typing import Any
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 print("==== PYTHONPATH ====")
@@ -41,24 +43,89 @@ def get_idx(header_row):
     return {h.strip(): i for i, h in enumerate(header_row)}
 
 
-def _clean_token(token_raw):
-    if token_raw is None:
+@dataclass
+class TokenCleanResult:
+    token: str | None
+    error: str | None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def _mask_value(value: str) -> str:
+    if not value:
         return ''
+    if len(value) <= 2:
+        return '*' * len(value)
+    return f"{value[0]}{'*' * (len(value) - 2)}{value[-1]}"
+
+
+def _describe_non_ascii(value: str):
+    return [
+        {
+            'index': idx,
+            'char': ch,
+            'ord': ord(ch),
+        }
+        for idx, ch in enumerate(value)
+        if not ch.isascii()
+    ]
+
+
+def _clean_token(token_raw):
+    details: dict[str, Any] = {'original': token_raw}
+
+    if token_raw is None:
+        details['reason'] = 'missing'
+        return TokenCleanResult(token=None, error='Token_WB отсутствует', details=details)
 
     raw_string = str(token_raw)
+    details['raw'] = raw_string
     chars_to_remove = " \t\r\n\"'\u00a0\ufeff"
     translation_table = str.maketrans('', '', chars_to_remove)
     cleaned = raw_string.translate(translation_table).strip()
+    details['cleaned'] = cleaned
 
     if cleaned.casefold() in {'', 'nan', 'none'}:
-        return ''
+        details['reason'] = 'empty_after_cleaning'
+        return TokenCleanResult(token=None, error='Token_WB пустой после очистки', details=details)
 
-    try:
-        cleaned.encode('latin-1')
-    except UnicodeEncodeError as exc:
-        raise ValueError('Token_WB содержит недопустимые символы') from exc
+    if not cleaned.isascii():
+        offending = _describe_non_ascii(cleaned)
+        masked = _mask_value(cleaned)
+        details.update({
+            'reason': 'non_ascii',
+            'masked_token': masked,
+            'length': len(cleaned),
+            'offending_characters': offending,
+        })
+        print('❌ Token_WB содержит недопустимые символы (не-ASCII).')
+        print(f"    Маска токена: {masked} (длина: {len(cleaned)})")
+        for item in offending:
+            char_repr = repr(item['char'])
+            print(f"    Недопустимый символ: {char_repr} (index={item['index']}, ord={item['ord']})")
+        return TokenCleanResult(token=None, error='Token_WB содержит недопустимые символы', details=details)
 
-    return cleaned
+    details.update({
+        'masked_token': _mask_value(cleaned),
+        'length': len(cleaned),
+    })
+    return TokenCleanResult(token=cleaned, error=None, details=details)
+
+
+def _validate_headers_ascii(headers, *, context: str = 'HTTP headers'):
+    for key, value in headers.items():
+        for label, text in (('ключ', key), ('значение', value)):
+            text_str = '' if text is None else str(text)
+            if not text_str.isascii():
+                masked = _mask_value(text_str)
+                offending = _describe_non_ascii(text_str)
+                target = 'ключ заголовка' if label == 'ключ' else 'значение заголовка'
+                print(f'❌ {context}: {target} {key!r} содержит недопустимые символы.')
+                print(f"    Маска строки: {masked} (длина: {len(text_str)})")
+                for item in offending:
+                    char_repr = repr(item['char'])
+                    print(f"    Недопустимый символ: {char_repr} (index={item['index']}, ord={item['ord']})")
+                return False
+    return True
 
 def main():
     print('=== START import_wb_product_cards ===')
@@ -109,28 +176,29 @@ def main():
         token_raw = row[idx['Token_WB']]
         org_name = '' if org is None else str(org)
         print(f'--- Организация "{org_name}"')
-        try:
-            token_clean = _clean_token(token_raw)
-        except ValueError:
-            print(f'❌ Некорректный Token_WB у организации "{org_name}"')
+        token_result = _clean_token(token_raw)
+        if token_result.error:
+            print(f'❌ Некорректный Token_WB у организации "{org_name}": {token_result.error}')
             continue
-        if not token_clean:
-            print(f'❌ Некорректный Token_WB у организации "{org_name}"')
-            continue
+        token_clean = token_result.token
         if not org:
             print('Строка пропущена (нет org)')
             continue
         cursor = None
         page = 0
         existSet = set()
-        session = _session_with_retries()
+        session = None
         headers = {
             'Authorization': token_clean,
             'Accept': 'application/json',
             'Content-Type': 'application/json',
             'User-Agent': 'FinmodelWB/1.0',
         }
+        if not _validate_headers_ascii(headers, context=f'HTTP-заголовки для организации "{org_name}"'):
+            print('Строка пропущена из-за недопустимых символов в HTTP-заголовках')
+            continue
         try:
+            session = _session_with_retries()
             while True:
                 page += 1
                 payload = {
@@ -185,7 +253,8 @@ def main():
                 cursor = {k: cur[k] for k in ('updatedAt','nmID') if k in cur}
                 cursor['limit'] = LIMIT
         finally:
-            session.close()
+            if session is not None:
+                session.close()
 
     if allCards:
         sht_prod.range((2, 1)).value = allCards


### PR DESCRIPTION
## Summary
- return structured results from `_clean_token`, enforce ASCII tokens, and log detailed metadata for invalid characters
- add reusable helpers for masking values and reporting non-ASCII characters
- validate HTTP headers before requests and skip rows with invalid headers while keeping the request loop unchanged otherwise

## Testing
- ruff check .
- pytest -q *(fails: ModuleNotFoundError: No module named 'pandas'; ModuleNotFoundError: No module named 'scripts')*

------
https://chatgpt.com/codex/tasks/task_e_68cbdeaab7b4832aa698b18a5a7e8d2a